### PR TITLE
#88 Prepare for publishing to Sonatype Maven Central

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - id: checkou-code
+      - id: checkout-code
         name: Checkout code
         uses: actions/checkout@v3
       - id: setup-java-and-maven-settings  
@@ -22,11 +22,11 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          # The following creates a a <server> block in the Maven settings.xml
+          # The following creates a <server> block in the Maven settings.xml
           server-id: ossrh
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD
-      - id: install-secret-key
+      - id: install-gpg-secret-key
         name: Install gpg secret key
         run: |
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
@@ -36,10 +36,10 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-        run: |
-          mvn \
-          --no-transfer-progress \
-          --batch-mode \
+        run: >
+          mvn
+          --no-transfer-progress
+          --batch-mode
           -Dgpg.keyname=${{ secrets.OSSRH_GPG_SECRET_KEY_ID }}
-          -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} \
+          -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
           clean deploy

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,34 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
+  <name>Type Factory</name>
+  <description>A set of modules designed to make creating custom data types easy.</description>
+  <url>https://github.com/type-factory/type-factory</url>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Evan Toliopoulos</name>
+      <email>evantoli@typefactory.org</email>
+      <organizationUrl>https://github.com/type-factory/type-factory</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git@github.com:type-factory/type-factory.git</connection>
+    <developerConnection>scm:git:git@github.com:type-factory/type-factory.git</developerConnection>
+    <url>https://github.com/type-factory/type-factory</url>
+  </scm>
+
   <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -42,6 +69,17 @@
     <module>type-factory-core</module>
     <module>type-factory-bom</module>
   </modules>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
 
   <dependencyManagement>
     <dependencies>
@@ -211,18 +249,17 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
         <version>1.3.0</version>
-        <configuration></configuration>
         <executions>
-          <!-- enable flattening -->
           <execution>
+            <!-- enable flattening -->
             <id>flatten</id>
             <phase>process-resources</phase>
             <goals>
               <goal>flatten</goal>
             </goals>
           </execution>
-          <!-- ensure proper cleanup -->
           <execution>
+            <!-- ensure proper cleanup -->
             <id>flatten.clean</id>
             <phase>clean</phase>
             <goals>
@@ -236,11 +273,72 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.10.1</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>3.0.0</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>3.0.0-M7</version>
         <configuration>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <useReleaseProfile>false</useReleaseProfile>
+          <!-- The <id> of our release profile below -->
+          <releaseProfiles>release</releaseProfiles>
+          <goals>deploy</goals>
         </configuration>
       </plugin>
+
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <!--          <plugin>-->
+          <!--            <groupId>org.sonatype.plugins</groupId>-->
+          <!--            <artifactId>nexus-staging-maven-plugin</artifactId>-->
+          <!--            <version>1.6.12</version>-->
+          <!--            <extensions>true</extensions>-->
+          <!--            <configuration>-->
+          <!--              <serverId>ossrh</serverId>-->
+          <!--              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>-->
+          <!--              <autoReleaseAfterClose>false</autoReleaseAfterClose>-->
+          <!--            </configuration>-->
+          <!--          </plugin>-->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                  <keyname>${gpg.keyname}</keyname>
+                  <passphraseServerId>${gpg.keyname}</passphraseServerId>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 
 </project>

--- a/type-factory-bom/pom.xml
+++ b/type-factory-bom/pom.xml
@@ -8,9 +8,45 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
+  <name>Type Factory Bill-of-Materials</name>
+  <description>A set of modules designed to make creating custom data types easy.</description>
+  <url>https://github.com/type-factory/type-factory</url>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Evan Toliopoulos</name>
+      <email>evantoli@typefactory.org</email>
+      <organizationUrl>https://github.com/type-factory/type-factory</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git@github.com:type-factory/type-factory.git</connection>
+    <developerConnection>scm:git:git@github.com:type-factory/type-factory.git</developerConnection>
+    <url>https://github.com/type-factory/type-factory</url>
+  </scm>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
   <properties>
-    <type-factory-core-version>${project.version}</type-factory-core-version>
-    <type-factory-language-version>${project.version}</type-factory-language-version>
+    <type-factory-core.version>${project.version}</type-factory-core.version>
+    <type-factory-language.version>${project.version}</type-factory-language.version>
   </properties>
 
   <dependencyManagement>
@@ -18,12 +54,12 @@
       <dependency>
         <groupId>org.typefactory</groupId>
         <artifactId>type-factory-core</artifactId>
-        <version>${type-factory-core-version}</version>
+        <version>${type-factory-core.version}</version>
       </dependency>
       <dependency>
         <groupId>org.typefactory</groupId>
         <artifactId>type-factory-language</artifactId>
-        <version>${type-factory-language-version}</version>
+        <version>${type-factory-language.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/type-factory-core/pom.xml
+++ b/type-factory-core/pom.xml
@@ -13,6 +13,25 @@
   <artifactId>type-factory-core</artifactId>
   <packaging>jar</packaging>
 
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Evan Toliopoulos</name>
+      <email>evantoli@typefactory.org</email>
+      <organizationUrl>https://github.com/type-factory/type-factory</organizationUrl>
+    </developer>
+  </developers>
+
+  <properties>
+    <maven.deploy.skip>false</maven.deploy.skip>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/type-factory-examples/pom.xml
+++ b/type-factory-examples/pom.xml
@@ -12,6 +12,25 @@
   <artifactId>type-factory-examples</artifactId>
   <packaging>jar</packaging>
 
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Evan Toliopoulos</name>
+      <email>evantoli@typefactory.org</email>
+      <organizationUrl>https://github.com/type-factory/type-factory</organizationUrl>
+    </developer>
+  </developers>
+
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/type-factory-language-code-generator/pom.xml
+++ b/type-factory-language-code-generator/pom.xml
@@ -12,6 +12,25 @@
   <artifactId>type-factory-language-code-generator</artifactId>
   <packaging>jar</packaging>
 
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Evan Toliopoulos</name>
+      <email>evantoli@typefactory.org</email>
+      <organizationUrl>https://github.com/type-factory/type-factory</organizationUrl>
+    </developer>
+  </developers>
+
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/type-factory-language/pom.xml
+++ b/type-factory-language/pom.xml
@@ -13,6 +13,25 @@
   <artifactId>type-factory-language</artifactId>
   <packaging>jar</packaging>
 
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Evan Toliopoulos</name>
+      <email>evantoli@typefactory.org</email>
+      <organizationUrl>https://github.com/type-factory/type-factory</organizationUrl>
+    </developer>
+  </developers>
+
+  <properties>
+    <maven.deploy.skip>false</maven.deploy.skip>
+  </properties>
+
   <dependencies>
 
     <dependency>


### PR DESCRIPTION
Prepare for publishing to Sonatype Maven Central:

- update the `pom.xml` files
- tweak the `.github/workflows/maven-publish.yml`