### PR TITLE
update pom files to fix maven-flatten-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,10 @@
             <goals>
               <goal>flatten</goal>
             </goals>
+            <configuration>
+              <!-- We want to keep the following POM elements in the flattened POM files because Sonatype Maven Central requires them -->
+              <pomElements><name/><description/><url/><scm/><developers/><contributors/></pomElements>
+            </configuration>
           </execution>
           <execution>
             <!-- ensure proper cleanup -->

--- a/type-factory-bom/pom.xml
+++ b/type-factory-bom/pom.xml
@@ -8,8 +8,8 @@
   <version>1.0.0</version>
   <packaging>pom</packaging>
 
-  <name>${project.artifactId}</name>
-  <description>A bill-of-materials providing dependencies to type-factory modules.</description>
+  <name>Type Factory – Bill-of-Materials (BOM)</name>
+  <description>The Type Factory bill-of-materials providing dependencies to all type-factory modules.</description>
   <url>https://github.com/type-factory/type-factory</url>
 
   <licenses>

--- a/type-factory-core/pom.xml
+++ b/type-factory-core/pom.xml
@@ -15,22 +15,6 @@
 
   <name>Type Factory – Core</name>
   <description>The Type Factory core library – contains the core classes and interfaces needed to make creating custom data types easy.</description>
-  <url>https://github.com/type-factory/type-factory</url>
-
-  <licenses>
-    <license>
-      <name>The Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <name>Evan Toliopoulos</name>
-      <email>evantoli+info@typefactory.org</email>
-      <organizationUrl>https://github.com/type-factory/type-factory</organizationUrl>
-    </developer>
-  </developers>
 
   <properties>
     <maven.deploy.skip>false</maven.deploy.skip>

--- a/type-factory-examples/pom.xml
+++ b/type-factory-examples/pom.xml
@@ -12,21 +12,6 @@
   <artifactId>type-factory-examples</artifactId>
   <packaging>jar</packaging>
 
-  <licenses>
-    <license>
-      <name>The Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <name>Evan Toliopoulos</name>
-      <email>evantoli+info@typefactory.org</email>
-      <organizationUrl>https://github.com/type-factory/type-factory</organizationUrl>
-    </developer>
-  </developers>
-
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>

--- a/type-factory-language-code-generator/pom.xml
+++ b/type-factory-language-code-generator/pom.xml
@@ -12,21 +12,6 @@
   <artifactId>type-factory-language-code-generator</artifactId>
   <packaging>jar</packaging>
 
-  <licenses>
-    <license>
-      <name>The Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <name>Evan Toliopoulos</name>
-      <email>evantoli+info@typefactory.org</email>
-      <organizationUrl>https://github.com/type-factory/type-factory</organizationUrl>
-    </developer>
-  </developers>
-
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
     <!-- TODO add coverage to the generator code -->

--- a/type-factory-language/pom.xml
+++ b/type-factory-language/pom.xml
@@ -17,21 +17,6 @@
   <description>The Type Factory language library – contains some useful language alphabets to use with the core library to make creating custom data types easy.</description>
   <url>https://github.com/type-factory/type-factory</url>
 
-  <licenses>
-    <license>
-      <name>The Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <name>Evan Toliopoulos</name>
-      <email>evantoli+info@typefactory.org</email>
-      <organizationUrl>https://github.com/type-factory/type-factory</organizationUrl>
-    </developer>
-  </developers>
-
   <properties>
     <maven.deploy.skip>false</maven.deploy.skip>
   </properties>


### PR DESCRIPTION
update pom files to fix maven-flatten-plugin to provide all elements  that are required by Sonatype Maven Central