### PR TITLE
Updated type-factory-bom pom file

### DIFF
--- a/type-factory-bom/pom.xml
+++ b/type-factory-bom/pom.xml
@@ -95,4 +95,38 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>publish</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                  <!--suppress UnresolvedMavenProperty -->
+                  <keyname>${env.GPG_KEY_ID}</keyname>
+                  <!--suppress UnresolvedMavenProperty -->
+                  <passphrase>${env.GPG_PASSPHRASE}</passphrase>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
Updated type-factory-bom pom file to ensure the maven-gpg-plugin plugin signs the BOM artifacts as required by Sonatype Maven Central