### PR TITLE
Issue #197 – Added the ability to detect corrupt char sequences with incomplete supplementary code points.

### DIFF
--- a/type-factory-core/src/main/java/org/typefactory/InvalidValueException.java
+++ b/type-factory-core/src/main/java/org/typefactory/InvalidValueException.java
@@ -199,7 +199,7 @@ public class InvalidValueException extends IllegalArgumentException {
     private MessageCode messageCode;
     private ParserMessageCode parserMessageCode;
 
-    private LinkedHashMap<String, Serializable> parserMessageCodeArgs = new LinkedHashMap<>();
+    private final LinkedHashMap<String, Serializable> parserMessageCodeArgs = new LinkedHashMap<>();
     private String invalidValue;
 
     /**
@@ -270,7 +270,7 @@ public class InvalidValueException extends IllegalArgumentException {
      *              will silently ignore attempts to add parser message arguments that are provided with a null or blank {@code key}.
      * @param value the message argument value.
      * @param <V>   message argument values must be serializable because the {@link InvalidValueException} class is serializable.
-     * @return
+     * @return this builder
      */
     public <V extends Serializable> InvalidValueExceptionBuilder addParserMessageCodeArg(final String key, final V value) {
       if (key != null && !key.isBlank()) {
@@ -390,6 +390,46 @@ public class InvalidValueException extends IllegalArgumentException {
     ParserMessageCode INVALID_VALUE_INVALID_WHITESPACE_CHARACTER = Factory.parserMessageCode(
         "invalid_value_invalid_whitespace_character",
         "Invalid value - invalid white-space character {0}.");
+
+    /**
+     * In the <a href="https://www.unicode.org/glossary/">Unicode documentation</a>, a surrogate code point is:
+     * <blockquote>
+     *   A Unicode code point in the range U+D800..U+DFFF. Reserved for use by UTF-16,
+     *   where a pair of surrogate code units (a
+     *   <a href="https://www.unicode.org/glossary/#high_surrogate_code_unit">high surrogate</a>
+     *   followed by a <a href="https://www.unicode.org/glossary/#low_surrogate_code_unit">low surrogate</a>)
+     *   “stand in” for a <a href="https://www.unicode.org/glossary/#supplementary_code_point">supplementary code point</a>.
+     * </blockquote>
+     *
+     * @see <a href="https://www.unicode.org/glossary/#surrogate_code_point">Surrogate code point</a>
+     * @see <a href="https://www.unicode.org/glossary/#surrogate_pair">Surrogate pair</a>
+     * @see <a href="https://www.unicode.org/glossary/#high_surrogate_code_unit">High-surrogate code unit</a>
+     * @see <a href="https://www.unicode.org/glossary/#low_surrogate_code_unit">Low-surrogate code unit</a>
+     * @see <a href="https://www.unicode.org/glossary/#supplementary_code_point">Supplementary code point</a>
+     */
+    ParserMessageCode INVALID_VALUE_HIGH_SURROGATE_WITHOUT_LOW_SURROGATE = Factory.parserMessageCode(
+        "invalid_value_high_surrogate_without_low_surrogate",
+        "Invalid value - incomplete surrogate-pair, low-surrogate code unit missing for the high-surrogate code unit {0}.");
+
+    /**
+     * In the <a href="https://www.unicode.org/glossary/">Unicode documentation</a>, a surrogate code point is:
+     * <blockquote>
+     *   A Unicode code point in the range U+D800..U+DFFF. Reserved for use by UTF-16,
+     *   where a pair of surrogate code units (a
+     *   <a href="https://www.unicode.org/glossary/#high_surrogate_code_unit">high surrogate</a>
+     *   followed by a <a href="https://www.unicode.org/glossary/#low_surrogate_code_unit">low surrogate</a>)
+     *   “stand in” for a <a href="https://www.unicode.org/glossary/#supplementary_code_point">supplementary code point</a>.
+     * </blockquote>
+     *
+     * @see <a href="https://www.unicode.org/glossary/#surrogate_code_point">Surrogate code point</a>
+     * @see <a href="https://www.unicode.org/glossary/#surrogate_pair">Surrogate pair</a>
+     * @see <a href="https://www.unicode.org/glossary/#high_surrogate_code_unit">High-surrogate code unit</a>
+     * @see <a href="https://www.unicode.org/glossary/#low_surrogate_code_unit">Low-surrogate code unit</a>
+     * @see <a href="https://www.unicode.org/glossary/#supplementary_code_point">Supplementary code point</a>
+     */
+    ParserMessageCode INVALID_VALUE_LOW_SURROGATE_WITHOUT_HIGH_SURROGATE = Factory.parserMessageCode(
+        "invalid_value_low_surrogate_without_high_surrogate",
+        "Invalid value - incomplete surrogate-pair, high-surrogate code unit missing for the low-surrogate code unit {0}.");
     ParserMessageCode INVALID_VALUE_TOO_LONG = Factory.parserMessageCode(
         "invalid_value_too_long",
         "Invalid value - too long, maximum length is {0,number,integer}.");

--- a/type-factory-core/src/main/java/org/typefactory/InvalidValueException.java
+++ b/type-factory-core/src/main/java/org/typefactory/InvalidValueException.java
@@ -409,7 +409,7 @@ public class InvalidValueException extends IllegalArgumentException {
      */
     ParserMessageCode INVALID_VALUE_HIGH_SURROGATE_WITHOUT_LOW_SURROGATE = Factory.parserMessageCode(
         "invalid_value_high_surrogate_without_low_surrogate",
-        "Invalid value - incomplete surrogate-pair, low-surrogate code unit missing for the high-surrogate code unit {0}.");
+        "Invalid value - incomplete surrogate-pair - the low-surrogate code unit is missing for the high-surrogate code unit {0}.");
 
     /**
      * In the <a href="https://www.unicode.org/glossary/">Unicode documentation</a>, a surrogate code point is:
@@ -429,7 +429,7 @@ public class InvalidValueException extends IllegalArgumentException {
      */
     ParserMessageCode INVALID_VALUE_LOW_SURROGATE_WITHOUT_HIGH_SURROGATE = Factory.parserMessageCode(
         "invalid_value_low_surrogate_without_high_surrogate",
-        "Invalid value - incomplete surrogate-pair, high-surrogate code unit missing for the low-surrogate code unit {0}.");
+        "Invalid value - incomplete surrogate-pair - the high-surrogate code unit is missing for the low-surrogate code unit {0}.");
     ParserMessageCode INVALID_VALUE_TOO_LONG = Factory.parserMessageCode(
         "invalid_value_too_long",
         "Invalid value - too long, maximum length is {0,number,integer}.");

--- a/type-factory-core/src/main/java/org/typefactory/impl/ExceptionUtils.java
+++ b/type-factory-core/src/main/java/org/typefactory/impl/ExceptionUtils.java
@@ -113,6 +113,40 @@ public class ExceptionUtils {
         .build();
   }
 
+  static InvalidValueException forHighSurrogateWithoutLowSurrogate(
+      final MessageCode messageCode,
+      final Class<?> targetTypeClass,
+      final CharSequence value,
+      final int invalidCodePoint) {
+
+    return InvalidValueException.builder()
+        .invalidValue(value)
+        .targetTypeClass(targetTypeClass)
+        .messageCode(messageCode)
+        .parserMessageCode(ParserMessageCode.INVALID_VALUE_HIGH_SURROGATE_WITHOUT_LOW_SURROGATE)
+        .addParserMessageCodeArg(
+            ParserMessageCodeArgKeys.INVALID_CODE_POINT,
+            unicodeHexCode(invalidCodePoint))
+        .build();
+  }
+
+  static InvalidValueException forLowSurrogateWithoutHighSurrogate(
+      final MessageCode messageCode,
+      final Class<?> targetTypeClass,
+      final CharSequence value,
+      final int invalidCodePoint) {
+
+    return InvalidValueException.builder()
+        .invalidValue(value)
+        .targetTypeClass(targetTypeClass)
+        .messageCode(messageCode)
+        .parserMessageCode(ParserMessageCode.INVALID_VALUE_LOW_SURROGATE_WITHOUT_HIGH_SURROGATE)
+        .addParserMessageCodeArg(
+            ParserMessageCodeArgKeys.INVALID_CODE_POINT,
+            unicodeHexCode(invalidCodePoint))
+        .build();
+  }
+
   static InvalidValueException forValueNotMatchRegex(
       final MessageCode messageCode,
       final Class<?> targetTypeClass,
@@ -147,8 +181,8 @@ public class ExceptionUtils {
 
   static String unicodeHexCode(final int codePoint) {
     return Character.isSupplementaryCodePoint(codePoint)
-        ? String.format("U+%06x", codePoint)
-        : String.format("U+%04x", (short) codePoint);
+        ? String.format("U+%06X", codePoint)
+        : String.format("U+%04X", (short) codePoint);
   }
 
 }

--- a/type-factory-core/src/main/java/org/typefactory/impl/TypeParserImpl.java
+++ b/type-factory-core/src/main/java/org/typefactory/impl/TypeParserImpl.java
@@ -173,12 +173,12 @@ final class TypeParserImpl implements TypeParser {
         case CONVERT_EMPTY_TO_NULL -> null;
       };
     }
+
     int[] target = converter == null ? new int[length] : new int[Math.min(maxNumberOfCodePoints, length * 2)];
     boolean codePointWasWhitespace = true;
     boolean codePointIsRepeatedWhitespaceRequiringNormalisation = false;
     int sourceIndex = 0;
     int targetIndex = 0;
-    char ch;
     int codePoint;
     int[] toCodePoints;
     final int[] reusableSingleCodePointArray = new int[1];
@@ -186,22 +186,31 @@ final class TypeParserImpl implements TypeParser {
     ConverterResults converterResults = converter == null ? null : converter.createConverterResults();
 
     while (sourceIndex < length) {
-      ch = source.charAt(sourceIndex);
-      if (Character.isSurrogate(ch)) {
-        if (++sourceIndex < length) {
-          codePoint = Character.toCodePoint(ch, source.charAt(sourceIndex));
+      { // block to ensure that variable "ch" is limited in scope
+        final char ch = source.charAt(sourceIndex);
+        if (Character.isHighSurrogate(ch)) {
+          if (++sourceIndex < length) {
+            final char lowCh = source.charAt(sourceIndex);
+            if (Character.isLowSurrogate(lowCh)) {
+              codePoint = Character.toCodePoint(ch, lowCh);
+            } else {
+              throw ExceptionUtils.forHighSurrogateWithoutLowSurrogate(messageCode, targetTypeClass, source, ch);
+            }
+          } else {
+            throw ExceptionUtils.forHighSurrogateWithoutLowSurrogate(messageCode, targetTypeClass, source, ch);
+          }
+        } else if (Character.isLowSurrogate(ch)) {
+          throw ExceptionUtils.forLowSurrogateWithoutHighSurrogate(messageCode, targetTypeClass, source, ch);
         } else {
-          throw ExceptionUtils.forInvalidCodePoint(messageCode, targetTypeClass, source, ch);
+          codePoint = ch;
         }
-      } else {
-        codePoint = ch;
       }
 
       if (Character.isWhitespace(codePoint)) {
         switch (whiteSpace) {
           case FORBID_WHITESPACE:
             if (converter != null && !converter.isCodePointConversionRequired(codePoint, targetIndex, converterResults)) {
-              throw ExceptionUtils.forInvalidCodePoint(messageCode, targetTypeClass, source, ch);
+              throw ExceptionUtils.forInvalidCodePoint(messageCode, targetTypeClass, source, codePoint);
             }
             break;
           case PRESERVE_WHITESPACE:

--- a/type-factory-core/src/main/java/org/typefactory/impl/TypeParserImpl.java
+++ b/type-factory-core/src/main/java/org/typefactory/impl/TypeParserImpl.java
@@ -186,7 +186,7 @@ final class TypeParserImpl implements TypeParser {
     ConverterResults converterResults = converter == null ? null : converter.createConverterResults();
 
     while (sourceIndex < length) {
-      { // block to ensure that variable "ch" is limited in scope
+      { // Get the codepoint. The anonymous block ensures that variable "ch" is limited in scope.
         final char ch = source.charAt(sourceIndex);
         if (Character.isHighSurrogate(ch)) {
           if (++sourceIndex < length) {

--- a/type-factory-core/src/test/java/org/typefactory/impl/AbstractTypeParserTest.java
+++ b/type-factory-core/src/test/java/org/typefactory/impl/AbstractTypeParserTest.java
@@ -15,14 +15,215 @@
 */
 package org.typefactory.impl;
 
+import static org.typefactory.InvalidValueException.ParserMessageCode.INVALID_VALUE_HIGH_SURROGATE_WITHOUT_LOW_SURROGATE;
+import static org.typefactory.InvalidValueException.ParserMessageCode.INVALID_VALUE_LOW_SURROGATE_WITHOUT_HIGH_SURROGATE;
+
 import org.typefactory.StringType;
 
 public abstract class AbstractTypeParserTest {
 
+  /**
+   * A concrete custom {@link StringType} type that can be used in unit tests.
+   */
   static class SomeType extends StringType {
 
     private SomeType(final String value) {
       super(value);
+    }
+  }
+
+  /**
+   * The Caucasian Albanian alphabet is made up entirely of letters that are
+   * <a href="https://www.unicode.org/glossary/#supplementary_code_point">supplementary code points</a>
+   * in Unicode with each letter requiring two Java chars in UTF-16 strings.
+   *
+   * @see <a href="https://www.unicode.org/glossary/#supplementary_code_point">Supplementary code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_code_point">Surrogate code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_pair">Surrogate pair</a>
+   * @see <a href="https://www.unicode.org/glossary/#high_surrogate_code_unit">High-surrogate code unit</a>
+   * @see <a href="https://www.unicode.org/glossary/#low_surrogate_code_unit">Low-surrogate code unit</a>
+   */
+  protected static final int [] CAUCASIAN_ALBANIAN_ALPHABET_CODE_POINTS =
+      "𐔰𐔱𐔲𐔳𐔴𐔵𐔶𐔷𐔸𐔹𐔺𐔻𐔼𐔽𐔾𐔿𐕀𐕁𐕂𐕃𐕄𐕅𐕆𐕇𐕈𐕉𐕊𐕋𐕌𐕍𐕎𐕏𐕐𐕑𐕒𐕓𐕔𐕕𐕖𐕗𐕘𐕙𐕚𐕛𐕜𐕝𐕞𐕟𐕠𐕡𐕢𐕣".codePoints().toArray();
+
+  /**
+   * The Caucasian Albanian Letter Alt 𐔰 (U+10530) is a
+   * <a href="https://www.unicode.org/glossary/#supplementary_code_point">supplementary code point</a>
+   * in Unicode and requires two Java chars in UTF-16 strings.
+   *
+   * @see <a href="https://www.unicode.org/glossary/#supplementary_code_point">Supplementary code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_code_point">Surrogate code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_pair">Surrogate pair</a>
+   * @see <a href="https://www.unicode.org/glossary/#high_surrogate_code_unit">High-surrogate code unit</a>
+   * @see <a href="https://www.unicode.org/glossary/#low_surrogate_code_unit">Low-surrogate code unit</a>
+   */
+  protected static final String CAUCASIAN_ALBANIAN_LETTER_ALT = "𐔰";
+
+  /**
+   * The Caucasian Albanian Letter Bet 𐔱 (U+10531) is a
+   * <a href="https://www.unicode.org/glossary/#supplementary_code_point">supplementary code point</a>
+   * in Unicode and requires two Java chars in UTF-16 strings.
+   *
+   * @see <a href="https://www.unicode.org/glossary/#supplementary_code_point">Supplementary code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_code_point">Surrogate code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_pair">Surrogate pair</a>
+   * @see <a href="https://www.unicode.org/glossary/#high_surrogate_code_unit">High-surrogate code unit</a>
+   * @see <a href="https://www.unicode.org/glossary/#low_surrogate_code_unit">Low-surrogate code unit</a>
+   */
+  protected static final String CAUCASIAN_ALBANIAN_LETTER_BET = "𐔱";
+
+  /**
+   * The Caucasian Albanian Letter Gim 𐔲 (U+10532) is a
+   * <a href="https://www.unicode.org/glossary/#supplementary_code_point">supplementary code point</a>
+   * in Unicode and requires two Java chars in UTF-16 strings.
+   *
+   * @see <a href="https://www.unicode.org/glossary/#supplementary_code_point">Supplementary code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_code_point">Surrogate code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_pair">Surrogate pair</a>
+   * @see <a href="https://www.unicode.org/glossary/#high_surrogate_code_unit">High-surrogate code unit</a>
+   * @see <a href="https://www.unicode.org/glossary/#low_surrogate_code_unit">Low-surrogate code unit</a>
+   */
+  protected static final String CAUCASIAN_ALBANIAN_LETTER_GIM = "𐔲";
+
+  /**
+   * The Caucasian Albanian Letter Dat 𐔳 (U+10533) is a
+   * <a href="https://www.unicode.org/glossary/#supplementary_code_point">supplementary code point</a>
+   * in Unicode and requires two Java chars in UTF-16 strings.
+   *
+   * @see <a href="https://www.unicode.org/glossary/#supplementary_code_point">Supplementary code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_code_point">Surrogate code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_pair">Surrogate pair</a>
+   * @see <a href="https://www.unicode.org/glossary/#high_surrogate_code_unit">High-surrogate code unit</a>
+   * @see <a href="https://www.unicode.org/glossary/#low_surrogate_code_unit">Low-surrogate code unit</a>
+   */
+  protected static final String CAUCASIAN_ALBANIAN_LETTER_DAT = "𐔳";
+
+  /**
+   * The Caucasian Albanian Letter Car 𐕂 (U+10542) is a
+   * <a href="https://www.unicode.org/glossary/#supplementary_code_point">supplementary code point</a>
+   * in Unicode and requires two Java chars in UTF-16 strings.
+   *
+   * @see <a href="https://www.unicode.org/glossary/#supplementary_code_point">Supplementary code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_code_point">Surrogate code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_pair">Surrogate pair</a>
+   * @see <a href="https://www.unicode.org/glossary/#high_surrogate_code_unit">High-surrogate code unit</a>
+   * @see <a href="https://www.unicode.org/glossary/#low_surrogate_code_unit">Low-surrogate code unit</a>
+   */
+  protected static final String CAUCASIAN_ALBANIAN_LETTER_CAR = "𐕂";
+
+  /**
+   * The high-surrogate part of the Caucasian Albanian Letter Car 𐕂 (U+10542) which is a
+   * <a href="https://www.unicode.org/glossary/#supplementary_code_point">supplementary code point</a>
+   * in Unicode and requires two Java chars in UTF-16 strings.
+   *
+   * @see <a href="https://www.unicode.org/glossary/#supplementary_code_point">Supplementary code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_code_point">Surrogate code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_pair">Surrogate pair</a>
+   * @see <a href="https://www.unicode.org/glossary/#high_surrogate_code_unit">High-surrogate code unit</a>
+   * @see <a href="https://www.unicode.org/glossary/#low_surrogate_code_unit">Low-surrogate code unit</a>
+   */
+  protected static final char CAUCASIAN_ALBANIAN_LETTER_CAR_HIGH_SURROGATE_CHAR = CAUCASIAN_ALBANIAN_LETTER_CAR.charAt(0);
+
+  /**
+   * The low-surrogate part of the Caucasian Albanian Letter Car 𐕂 (U+10542) which is a
+   * <a href="https://www.unicode.org/glossary/#supplementary_code_point">supplementary code point</a>
+   * in Unicode and requires two Java chars in UTF-16 strings.
+   *
+   * @see <a href="https://www.unicode.org/glossary/#supplementary_code_point">Supplementary code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_code_point">Surrogate code point</a>
+   * @see <a href="https://www.unicode.org/glossary/#surrogate_pair">Surrogate pair</a>
+   * @see <a href="https://www.unicode.org/glossary/#high_surrogate_code_unit">High-surrogate code unit</a>
+   * @see <a href="https://www.unicode.org/glossary/#low_surrogate_code_unit">Low-surrogate code unit</a>
+   */
+  protected static final char CAUCASIAN_ALBANIAN_LETTER_CAR_LOW_SURROGATE_CHAR = CAUCASIAN_ALBANIAN_LETTER_CAR.charAt(1);
+
+  /**
+   * <p>An enum that can be used in parameterized unit tests where each enum value
+   * is an instance of a corrupt {@link CharSequence} where a
+   * <a href="https://www.unicode.org/glossary/#supplementary_code_point">supplementary code point</a>
+   * is missing either a <a href="https://www.unicode.org/glossary/#high_surrogate_code_unit">high-surrogate code unit</a>
+   * or a <a href="https://www.unicode.org/glossary/#low_surrogate_code_unit">low-surrogate code unit</a>.</p>
+   *
+   * <p>Each enum value also contains the expected error message pattern for the thrown
+   * {@link org.typefactory.InvalidValueException}</p>
+   */
+  protected enum CorruptCharSequence implements CharSequence {
+
+    SEQUENCE_WITH_ONLY_HIGH_SURROGATE_WITHOUT_LOW_SURROGATE(
+        INVALID_VALUE_HIGH_SURROGATE_WITHOUT_LOW_SURROGATE.defaultMessage().replace("{0}", "U+D801"),
+        CAUCASIAN_ALBANIAN_LETTER_CAR_HIGH_SURROGATE_CHAR),
+
+    SEQUENCE_WITH_ONLY_LOW_SURROGATE_WITHOUT_HIGH_SURROGATE(
+        INVALID_VALUE_LOW_SURROGATE_WITHOUT_HIGH_SURROGATE.defaultMessage().replace("{0}", "U+DD42"),
+        CAUCASIAN_ALBANIAN_LETTER_CAR_LOW_SURROGATE_CHAR),
+
+    SEQUENCE_STARTING_WITH_HIGH_SURROGATE_WITHOUT_LOW_SURROGATE(
+        INVALID_VALUE_HIGH_SURROGATE_WITHOUT_LOW_SURROGATE.defaultMessage().replace("{0}", "U+D801"),
+        CAUCASIAN_ALBANIAN_LETTER_CAR_HIGH_SURROGATE_CHAR,
+        CAUCASIAN_ALBANIAN_LETTER_ALT.charAt(0),
+        CAUCASIAN_ALBANIAN_LETTER_ALT.charAt(1)),
+
+    SEQUENCE_STARTING_WITH_LOW_SURROGATE_WITHOUT_HIGH_SURROGATE(
+        INVALID_VALUE_LOW_SURROGATE_WITHOUT_HIGH_SURROGATE.defaultMessage().replace("{0}", "U+DD42"),
+        CAUCASIAN_ALBANIAN_LETTER_CAR_LOW_SURROGATE_CHAR,
+        CAUCASIAN_ALBANIAN_LETTER_ALT.charAt(0),
+        CAUCASIAN_ALBANIAN_LETTER_ALT.charAt(1)),
+
+    SEQUENCE_CONTAINING_HIGH_SURROGATE_WITHOUT_LOW_SURROGATE(
+        INVALID_VALUE_HIGH_SURROGATE_WITHOUT_LOW_SURROGATE.defaultMessage().replace("{0}", "U+D801"),
+        CAUCASIAN_ALBANIAN_LETTER_BET.charAt(0),
+        CAUCASIAN_ALBANIAN_LETTER_BET.charAt(1),
+        CAUCASIAN_ALBANIAN_LETTER_CAR_HIGH_SURROGATE_CHAR,
+        CAUCASIAN_ALBANIAN_LETTER_GIM.charAt(0),
+        CAUCASIAN_ALBANIAN_LETTER_GIM.charAt(1)),
+
+    SEQUENCE_CONTAINING_LOW_SURROGATE_WITHOUT_HIGH_SURROGATE(
+        INVALID_VALUE_LOW_SURROGATE_WITHOUT_HIGH_SURROGATE.defaultMessage().replace("{0}", "U+DD42"),
+        CAUCASIAN_ALBANIAN_LETTER_BET.charAt(0),
+        CAUCASIAN_ALBANIAN_LETTER_BET.charAt(1),
+        CAUCASIAN_ALBANIAN_LETTER_CAR_LOW_SURROGATE_CHAR,
+        CAUCASIAN_ALBANIAN_LETTER_GIM.charAt(0),
+        CAUCASIAN_ALBANIAN_LETTER_GIM.charAt(1)),
+
+    SEQUENCE_ENDING_WITH_HIGH_SURROGATE_WITHOUT_LOW_SURROGATE(
+        INVALID_VALUE_HIGH_SURROGATE_WITHOUT_LOW_SURROGATE.defaultMessage().replace("{0}", "U+D801"),
+        CAUCASIAN_ALBANIAN_LETTER_DAT.charAt(0),
+        CAUCASIAN_ALBANIAN_LETTER_DAT.charAt(1),
+        CAUCASIAN_ALBANIAN_LETTER_CAR_HIGH_SURROGATE_CHAR),
+
+    SEQUENCE_ENDING_WITH_LOW_SURROGATE_WITHOUT_HIGH_SURROGATE(
+        INVALID_VALUE_LOW_SURROGATE_WITHOUT_HIGH_SURROGATE.defaultMessage().replace("{0}", "U+DD42"),
+        CAUCASIAN_ALBANIAN_LETTER_DAT.charAt(0),
+        CAUCASIAN_ALBANIAN_LETTER_DAT.charAt(1),
+        CAUCASIAN_ALBANIAN_LETTER_CAR_LOW_SURROGATE_CHAR),
+    ;
+
+    private final char [] chars;
+
+    private final String expectedErrorMessage;
+
+    CorruptCharSequence(final String expectedErrorMessage, final char... chars) {
+      this.expectedErrorMessage = expectedErrorMessage;
+      this.chars = chars;
+    }
+
+    public String getExpectedErrorMessage() {
+      return expectedErrorMessage;
+    }
+
+    @Override
+    public int length() {
+      return chars.length;
+    }
+
+    @Override
+    public char charAt(int index) {
+      return chars[index];
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+      return new String(chars, start, end - start);
     }
   }
 

--- a/type-factory-core/src/test/java/org/typefactory/impl/ExceptionUtilsTest.java
+++ b/type-factory-core/src/test/java/org/typefactory/impl/ExceptionUtilsTest.java
@@ -107,10 +107,8 @@ class ExceptionUtilsTest {
     final var actual = ExceptionUtils.forValueNotValidUsingCustomValidation(MESSAGE_CODE, SomeClass.class, someValue, cause);
     assertThat(actual)
         .isInstanceOf(InvalidValueException.class)
-        .satisfies(exception -> {
-          assertThat(exception.getMessage()).
-              isEqualTo(MESSAGE_CODE.defaultMessage() + ". Invalid value - does not pass custom validation criteria.");
-        });
+        .satisfies(exception -> assertThat(exception.getMessage())
+            .isEqualTo(MESSAGE_CODE.defaultMessage() + ". Invalid value - does not pass custom validation criteria."));
   }
 
   @ParameterizedTest
@@ -119,7 +117,7 @@ class ExceptionUtilsTest {
       `\b` | U+0008
       '    | U+0027
       e    | U+0065
-      🈂    | U+01f202
+      🈂    | U+01F202
       """, delimiter = '|', quoteCharacter = '`')
   void unicodeHexCode(
       final String codePointAsString,

--- a/type-factory-core/src/test/java/org/typefactory/impl/TypeParserImpl_parseCorruptCharSequenceTest.java
+++ b/type-factory-core/src/test/java/org/typefactory/impl/TypeParserImpl_parseCorruptCharSequenceTest.java
@@ -1,0 +1,43 @@
+/*
+   Copyright 2021-2022 Evan Toliopoulos (typefactory.org)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.typefactory.impl;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.typefactory.InvalidValueException;
+import org.typefactory.TypeParser;
+
+class TypeParserImpl_parseCorruptCharSequenceTest extends AbstractTypeParserTest {
+
+  @ParameterizedTest
+  @EnumSource(CorruptCharSequence.class)
+  void parseToString_throwsExceptionWhenHighOrLowSurrogateIsMissing(final CorruptCharSequence corruptCharSequence) {
+
+    final var typeParser = TypeParser.builder()
+        // Accepting code points in the Caucasian Albanian alphabet U+10530..U+10563.
+        // Each of these letters require two chars in Java UTF-16.
+        // Note that the test values are all Caucasian Albanian char-sequences.
+        .acceptCodePoints(CAUCASIAN_ALBANIAN_ALPHABET_CODE_POINTS)
+        .removeAllWhitespace()
+        .build();
+
+    assertThatExceptionOfType(InvalidValueException.class)
+        .isThrownBy(() -> typeParser.parseToString(corruptCharSequence))
+        .withMessage(corruptCharSequence.getExpectedErrorMessage());
+  }
+}


### PR DESCRIPTION
Added the ability to detect corrupt char sequences with incomplete supplementary code points

For example:

- a high-surrogate code unit without a corresponding low-surrogate code unit
- a low-surrogate code unit without a corresponding high-surrogate code unit

In the Unicode documentation, a supplementary code point is a Unicode code point between U+10000 and U+10FFFF and requires a surrogate pair to represent the code point using two Java UTF-16 char values in a sequence. These two char values are Unicode surrogate code points which are:

> A Unicode code point in the range U+D800..U+DFFF. Reserved for use by UTF-16, where a pair of surrogate code units (a high surrogate code unit followed by a low surrogate code unit) “stand in” for a supplementary code point.