### PR TITLE
feature(287): Added ability to convert Unicode decimal digits to digits specified by a target zero-digit.

### DIFF
--- a/type-factory-core/src/main/java/org/typefactory/TypeParser.java
+++ b/type-factory-core/src/main/java/org/typefactory/TypeParser.java
@@ -951,6 +951,12 @@ public interface TypeParser {
      */
     TypeParserBuilder convertCodePoint(int fromCodePoint, CharSequence toCharSequence);
 
+    default TypeParserBuilder convertAnyDecimalDigitsToDigitsStartingWithZeroDigit(final char zeroDigitChar) {
+      return convertAnyDecimalDigitsToDigitsStartingWithZeroDigit((int) zeroDigitChar);
+    }
+
+    TypeParserBuilder convertAnyDecimalDigitsToDigitsStartingWithZeroDigit(final int zeroDigitCodePoint);
+
     /**
      * <p>Configures the type-parser to convert any code-point (character) in the Unicode {@code fromCategory} in the input sequence to a {@code toChar}.</p>
      *
@@ -1359,6 +1365,20 @@ public interface TypeParser {
      * @see <a href="https://unicode.org/reports/tr44/#General_Category_Values">Unicode General Character Categories</a>
      */
     TypeParserBuilder acceptAllUnicodeLetters();
+
+    /**
+     * <p>A convenience method that is the same as calling:</p>
+     * <pre>{@code
+     *   acceptUnicodeCategory(Category.DECIMAL_DIGIT_NUMBER)
+     * }</pre>
+     *
+     * <p>Essentially it accepts all characters/code-points found in the {@link Category#DECIMAL_DIGIT_NUMBER} composite category.</p>
+     *
+     * @return this {@code TypeParserBuilder}.
+     * @see #acceptUnicodeCategory(Category)
+     * @see <a href="https://unicode.org/reports/tr44/#General_Category_Values">Unicode General Character Categories</a>
+     */
+    TypeParserBuilder acceptAllUnicodeDecimalDigits();
 
     /**
      * <p>Configures the type parser to accepts all letters [a-zA-Z] that are in the <a href="https://unicode.org/charts/PDF/U0000.pdf">Basic

--- a/type-factory-core/src/main/java/org/typefactory/TypeParserBuilderException.java
+++ b/type-factory-core/src/main/java/org/typefactory/TypeParserBuilderException.java
@@ -1,0 +1,241 @@
+/*
+   Copyright 2021-2022 Evan Toliopoulos (typefactory.org)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.typefactory;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.typefactory.TypeParser.TypeParserBuilder;
+import org.typefactory.impl.Factory;
+
+/**
+ * <p>Thrown by the {@link TypeParserBuilder} when it is unable to configure or create a builder.</p>
+ *
+ * @author Evan Toliopoulos
+ */
+public class TypeParserBuilderException extends RuntimeException  {
+
+  @Serial
+  private static final long serialVersionUID = -7198769839039479407L;
+
+  private static final String EMPTY_STRING = "";
+
+  /**
+   * Immutable empty array.
+   */
+  private static final Serializable[] EMPTY_MESSAGE_ARGS_ARRAY = new Serializable[0];
+
+  /**
+   * Immutable empty map.
+   */
+  private static final Map<String, Serializable> EMPTY_MESSAGE_ARGS_MAP = Map.of();
+
+  private static final MessageCode EMPTY_MESSAGE_CODE = Factory.messageCode(EMPTY_STRING, EMPTY_STRING);
+
+  private final MessageCode messageCode;
+
+  private final Map<String, Serializable> messageCodeArgs;
+
+  private final Serializable[] messageCodeArgsValues;
+
+  /**
+   * Provides a builder to create {@link TypeParserBuilderException} instances.
+   *
+   * @return a builder to create {@link TypeParserBuilderException} instances.
+   */
+  public static TypeParserBuilderExceptionBuilder builder() {
+    return new TypeParserBuilderExceptionBuilder();
+  }
+
+  /**
+   * Protected constructor – use the {@link #builder()} to create an {@code TypeParserBuilderException}.
+   *
+   * @param cause           the optional cause of the exception. Pass {@code null} if there is no cause.
+   * @param messageCode     the key used to find the error message in the {@code org.typefactory.Messages} resource-bundle or properties file. If no
+   *                        error message is found in the resource-bundle or properties file then this value will be used as the error message.
+   * @param messageCodeArgs the message arguments to supply to the message formatter used to create the error message.
+   * @see #builder()
+   */
+  protected TypeParserBuilderException(
+      final Throwable cause,
+      final MessageCode messageCode,
+      final LinkedHashMap<String, Serializable> messageCodeArgs) {
+    super(createMessage(messageCode, messageCodeArgs), cause);
+    this.messageCode = messageCode == null ? EMPTY_MESSAGE_CODE : messageCode;
+    this.messageCodeArgs = messageCodeArgs == null
+        ? EMPTY_MESSAGE_ARGS_MAP
+        : messageCodeArgs;
+    this.messageCodeArgsValues = messageCodeArgs == null
+        ? EMPTY_MESSAGE_ARGS_ARRAY
+        : messageCodeArgs.values().toArray(EMPTY_MESSAGE_ARGS_ARRAY);
+  }
+
+  private static String createMessage(final MessageCode messageCode, final Map<String, Serializable> messageCodeArgs) {
+    if (messageCode == null) {
+      return null;
+    }
+    if (messageCodeArgs == null) {
+      return messageCode.message();
+    }
+    return messageCode.message(messageCodeArgs.values().toArray(EMPTY_MESSAGE_ARGS_ARRAY));
+  }
+
+  /**
+   * <p>Provides a localized message using {@link Locale#getDefault()} as the desired locale.</p>
+   *
+   * <p>Consider using {@link #getLocalizedMessage(Locale)} to get a message localized to the specified locale.</p>
+   *
+   * @return a localized message using {@link Locale#getDefault()} as the desired locale.
+   * @see #getLocalizedMessage(Locale)
+   * @see #getMessage()
+   */
+  @Override
+  public String getLocalizedMessage() {
+    return getLocalizedMessage(Locale.getDefault());
+  }
+
+  /**
+   * <p>Provides a message localized to the specified {@code locale}.</p>
+   *
+   * @param locale the locale that you wish the message to be localized into.
+   * @return a message localized to the specified {@code locale}.
+   * @see #getLocalizedMessage()
+   * @see #getMessage()
+   */
+  public String getLocalizedMessage(final Locale locale) {
+    return messageCode.message(locale, messageCodeArgsValues);
+  }
+
+
+  public String getMessageCode() {
+    return messageCode.code();
+  }
+
+  public String getErrorMessage() {
+    return messageCode.message(messageCodeArgsValues);
+  }
+
+  public String getErrorMessage(final Locale locale) {
+    return messageCode.message(locale, messageCodeArgsValues);
+  }
+
+  public Map<String, Serializable> getErrorProperties() {
+    return messageCodeArgs;
+  }
+
+  /**
+   * A builder to create {@link TypeParserBuilderException} instances.
+   */
+  public static class TypeParserBuilderExceptionBuilder {
+
+    private Throwable cause;
+    private MessageCode messageCode;
+
+    private final LinkedHashMap<String, Serializable> messageCodeArgs = new LinkedHashMap<>();
+
+    /**
+     * Creates and returns an {@link TypeParserBuilderException} instance.
+     *
+     * @return an {@link TypeParserBuilderException} instance.
+     */
+    public TypeParserBuilderException build() {
+      return new TypeParserBuilderException(cause, messageCode, messageCodeArgs);
+    }
+
+    /**
+     * Set the cause of the exception you are creating.
+     *
+     * @param cause the cause of the exception.
+     * @return this builder
+     */
+    public TypeParserBuilderExceptionBuilder cause(final Throwable cause) {
+      this.cause = cause;
+      return this;
+    }
+
+    /**
+     * Set the key used to find the error message in the {@code org.typefactory.Messages} resource-bundle or properties file.
+     *
+     * @param messageCode the key used to find the error message in the {@code org.typefactory.Messages} resource-bundle or properties file. If no
+     *                    error message is found in the resource-bundle or properties file then the value you provide here will be used as the error
+     *                    message.
+     * @return this builder
+     */
+    public TypeParserBuilderExceptionBuilder messageCode(final MessageCode messageCode) {
+      this.messageCode = messageCode;
+      return this;
+    }
+
+    /**
+     * <p>Add message arguments to supply to the message formatter used to create the error message.</p>
+     *
+     * <p>Note: this method will silently ignore attempts to add parser message arguments that are provided with a null or blank {@code key}.</p>
+     *
+     * @param key   the message argument name. Note that this is ignored for purposes of message creation by the message formatter which uses argument
+     *              index only. It is captured solely to enable any exception handlers meaningful access to argument name-value pairs. This method
+     *              will silently ignore attempts to add message arguments that are provided with a null or blank {@code key}.
+     * @param value the message argument value.
+     * @param <V>   message argument values must be serializable because the {@link TypeParserBuilderException} class is serializable.
+     * @return this builder
+     */
+    public <V extends Serializable> TypeParserBuilderExceptionBuilder addMessageCodeArg(final String key, final V value) {
+      if (key != null && !key.isBlank()) {
+        this.messageCodeArgs.put(key, value);
+      }
+      return this;
+    }
+  }
+
+  /**
+   * <p>Provides a string representation of the {@link TypeParserBuilderException}.</p>
+   *
+   * @return a string representation of the {@link TypeParserBuilderException}.
+   */
+  @Override
+  public String toString() {
+    final StringBuilder s = new StringBuilder();
+    s.append(this.getClass().getSimpleName())
+        .append("{")
+        .append("message='").append(getMessage()).append('\'')
+        .append(", messageCode='").append(messageCode.code()).append('\'')
+        .append(", defaultErrorMessage='").append(messageCode.defaultMessage()).append('\'');
+    for (Map.Entry<String, Serializable> entry : messageCodeArgs.entrySet()) {
+      s.append(", ").append(entry.getKey()).append("='").append(entry.getValue()).append('\'');
+    }
+    if (getCause() != null) {
+      s.append(", cause='").append(getCause().getClass().getSimpleName()).append(" - ").append(getCause().getMessage()).append('\'');
+    }
+    s.append("}");
+    return s.toString();
+  }
+
+  /**
+   * <p>Message codes are used internally by the {@link TypeParserBuilder}.</p>
+   */
+  public static final class MessageCodes {
+
+    private MessageCodes() {
+      // don't instantiate me
+    }
+
+    public static final MessageCode INVALID_ZERO_DIGIT_EXCEPTION_MESSAGE = Factory.messageCode(
+        "invalid_zero_digit",
+        "An invalid zero digit has been configured for the type parser – the zero digit character must represent zero and the subsequent nine characters must be valid unicode decimal digits.");
+  }
+
+}

--- a/type-factory-core/src/main/java/org/typefactory/impl/TypeParserImpl.java
+++ b/type-factory-core/src/main/java/org/typefactory/impl/TypeParserImpl.java
@@ -44,6 +44,7 @@ final class TypeParserImpl implements TypeParser {
   private final Normalizer.Form targetCharacterNormalizationForm;
   private final int minNumberOfCodePoints;
   private final int maxNumberOfCodePoints;
+  private final int convertAnyDecimalDigitsToDigitsStartingWithZeroDigit;
 
   private final Pattern regex;
 
@@ -62,6 +63,7 @@ final class TypeParserImpl implements TypeParser {
       final Normalizer.Form targetCharacterNormalizationForm,
       final int minNumberOfCodePoints,
       final int maxNumberOfCodePoints,
+      final int convertAnyDecimalDigitsToDigitsStartingWithZeroDigit,
       final Pattern regex,
       final Predicate<String> validationFunction,
       final Subset acceptedCodePoints,
@@ -74,6 +76,7 @@ final class TypeParserImpl implements TypeParser {
     this.targetCharacterNormalizationForm = targetCharacterNormalizationForm;
     this.minNumberOfCodePoints = minNumberOfCodePoints;
     this.maxNumberOfCodePoints = maxNumberOfCodePoints;
+    this.convertAnyDecimalDigitsToDigitsStartingWithZeroDigit = convertAnyDecimalDigitsToDigitsStartingWithZeroDigit;
     this.regex = regex;
     this.validationFunction = validationFunction;
     this.acceptedCodePoints = acceptedCodePoints;
@@ -237,6 +240,10 @@ final class TypeParserImpl implements TypeParser {
         codePointWasWhitespace = true;
       } else {
         codePointWasWhitespace = false;
+      }
+
+      if (convertAnyDecimalDigitsToDigitsStartingWithZeroDigit > 0 && Character.isDigit(codePoint)) {
+        codePoint = convertAnyDecimalDigitsToDigitsStartingWithZeroDigit + Character.digit(codePoint, 10);
       }
 
       if (!isAcceptedCodePoint(codePoint) && !codePointWasWhitespace) {

--- a/type-factory-core/src/test/java/org/typefactory/Messages_de.java
+++ b/type-factory-core/src/test/java/org/typefactory/Messages_de.java
@@ -31,6 +31,11 @@ public class Messages_de extends ListResourceBundle {
         {"gggg", "einige Fehlermeldung-G."},
         {"hhhh", "einige Fehlermeldung-H."},
 
+        {"ee-e1", "einige Fehlermeldung-E mit Wert {0}."},
+        {"ff_f1", "einige Fehlermeldung-F mit Wert {0}."},
+        {"gggg1", "einige Fehlermeldung-G mit Wert {0}."},
+        {"hhhh1", "einige Fehlermeldung-H mit Wert {0}."},
+
         {"ss"  , "einige Parser-Fehlermeldungen-S."},
         {"tt"  , "einige Parser-Fehlermeldungen-T."},
         {"uu.u", "einige Parser-Fehlermeldungen-U."},

--- a/type-factory-core/src/test/java/org/typefactory/TypeParserBuilderExceptionTest.java
+++ b/type-factory-core/src/test/java/org/typefactory/TypeParserBuilderExceptionTest.java
@@ -1,0 +1,203 @@
+package org.typefactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TypeParserBuilderExceptionTest {
+
+  static final MessageCode ERROR_MESSAGE_CODE_NO_ARGS = MessageCode.of("some.error.code", "some default error message");
+
+  static final MessageCode ERROR_MESSAGE_CODE_WITH_ARGS = MessageCode.of("some.error.code", "some default error message because of {0}");
+
+  static final LinkedHashMap<String, Serializable> ERROR_MESSAGE_CODE_ARGS = new LinkedHashMap<>(Map.of("invalidCodePoint", "A"));
+
+  @Mock
+  Exception cause;
+
+  @Test
+  void constructor_withNoMessageCode() {
+    final var actual = new TypeParserBuilderException(cause, null, ERROR_MESSAGE_CODE_ARGS);
+
+    assertThat(actual.getCause()).isEqualTo(cause);
+    assertThat(actual.getMessage()).isNull();
+    assertThat(actual.getLocalizedMessage()).isNotNull().isEmpty();
+    assertThat(actual.getMessageCode()).isNotNull().isEmpty();
+    assertThat(actual.getErrorMessage()).isNotNull().isEmpty();
+    assertThat(actual.getErrorMessage(Locale.FRENCH)).isNotNull().isEmpty();
+  }
+
+  @Test
+  void constructor_withMessageCodeNoMessageArgs() {
+    final var actual = new TypeParserBuilderException(cause, ERROR_MESSAGE_CODE_NO_ARGS, null);
+
+    assertThat(actual.getCause()).isEqualTo(cause);
+    assertThat(actual.getMessage()).isEqualTo(ERROR_MESSAGE_CODE_NO_ARGS.defaultMessage());
+    assertThat(actual.getLocalizedMessage()).isEqualTo(ERROR_MESSAGE_CODE_NO_ARGS.defaultMessage());
+    assertThat(actual.getMessageCode()).isEqualTo(ERROR_MESSAGE_CODE_NO_ARGS.code());
+    assertThat(actual.getErrorMessage()).isEqualTo(ERROR_MESSAGE_CODE_NO_ARGS.defaultMessage());
+    assertThat(actual.getErrorMessage(Locale.FRENCH)).isEqualTo(ERROR_MESSAGE_CODE_NO_ARGS.defaultMessage());
+  }
+
+  @Test
+  void builder_withNoMessageCode() {
+    final var actual = TypeParserBuilderException.builder()
+        .cause(cause)
+        .addMessageCodeArg("invalidCodePoint", "A")
+        .build();
+
+    assertThat(actual.getCause()).isEqualTo(cause);
+    assertThat(actual.getMessage()).isNull();
+    assertThat(actual.getLocalizedMessage()).isNotNull().isEmpty();
+    assertThat(actual.getMessageCode()).isNotNull().isEmpty();
+    assertThat(actual.getErrorMessage()).isNotNull().isEmpty();
+    assertThat(actual.getErrorMessage(Locale.FRENCH)).isNotNull().isEmpty();
+  }
+
+  @Test
+  void builder_withMessageCodeNoMessageArgs() {
+    final var actual = TypeParserBuilderException.builder()
+        .cause(cause)
+        .messageCode(ERROR_MESSAGE_CODE_NO_ARGS)
+        .build();
+
+    assertThat(actual.getCause()).isEqualTo(cause);
+    assertThat(actual.getMessage()).isEqualTo(ERROR_MESSAGE_CODE_NO_ARGS.defaultMessage());
+    assertThat(actual.getLocalizedMessage()).isEqualTo(ERROR_MESSAGE_CODE_NO_ARGS.defaultMessage());
+    assertThat(actual.getMessageCode()).isEqualTo(ERROR_MESSAGE_CODE_NO_ARGS.code());
+    assertThat(actual.getErrorMessage()).isEqualTo(ERROR_MESSAGE_CODE_NO_ARGS.defaultMessage());
+    assertThat(actual.getErrorMessage(Locale.FRENCH)).isEqualTo(ERROR_MESSAGE_CODE_NO_ARGS.defaultMessage());
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = "  ")
+  void builder_constructsExceptionIgnoringNullOrBlankArgKey(final String argKey) {
+
+    final var actual = TypeParserBuilderException.builder()
+        .addMessageCodeArg(argKey, "A")
+        .build();
+
+    assertThat(actual.getErrorProperties()).isEmpty();
+  }
+
+  @Test
+  void builder_constructsExceptionWithNonBlankArgKey() {
+
+    final var actual = TypeParserBuilderException.builder()
+        .addMessageCodeArg("A", "B")
+        .build();
+
+    assertThat(actual.getErrorProperties()).containsAllEntriesOf(Map.of("A", "B"));
+  }
+
+  @ParameterizedTest
+  @CsvSource(textBlock = """
+      aa    | some error message-A.                | null | some error message-A.
+      bb    | some error message-B.                | ''   | some error message-B.
+      cc.c  | some error message-C.                | '  ' | some error message-C.
+      dc.d  | some error message-D.                | JJKK | some error message-D.
+      ee-e1 | some error message-E with value {0}. | null | some error message-E with value null.
+      ff_f1 | some error message-F with value {0}. | ''   | some error message-F with value .
+      gggg1 | some error message-G with value {0}. | '  ' | some error message-G with value   .
+      hhhh1 | some error message-H with value {0}. | JJKK | some error message-H with value JJKK.
+      """, delimiter = '|', nullValues = "null")
+  void getMessage_returnsAsExpected(
+      final String messageCodeString, final String messageCodeMessage,
+      final String errorMessageArg,
+      final String expectedMessage) {
+
+    final var messageCode = MessageCode.of(messageCodeString, messageCodeMessage);
+
+    final var typeParserBuilderException = TypeParserBuilderException.builder()
+        .messageCode(messageCode)
+        .addMessageCodeArg("some-arg", errorMessageArg)
+        .build();
+
+    final var actual = typeParserBuilderException.getMessage();
+
+    assertThat(actual)
+        .isNotNull()
+        .isNotEmpty()
+        .isEqualTo(expectedMessage);
+  }
+
+  @ParameterizedTest
+  @CsvSource(textBlock = """
+      xx | aa    | some error message-A.                | null | some error message-A.
+      xx | bb    | some error message-B.                | ''   | some error message-B.
+      xx | cc.c  | some error message-C.                | '  ' | some error message-C.
+      xx | dc.d  | some error message-D.                | JJKK | some error message-D.
+      xx | ee-e1 | some error message-E with value {0}. | null | some error message-E with value null.
+      xx | ff_f1 | some error message-F with value {0}. | ''   | some error message-F with value .
+      xx | gggg1 | some error message-G with value {0}. | '  ' | some error message-G with value   .
+      xx | hhhh1 | some error message-H with value {0}. | JJKK | some error message-H with value JJKK.
+
+      es | aa    | some error message-A.                | null | algún mensaje de error-A.
+      es | bb    | some error message-B.                | ''   | algún mensaje de error-B.
+      es | cc.c  | some error message-C.                | '  ' | algún mensaje de error-C.
+      es | dc.d  | some error message-D.                | JJKK | algún mensaje de error-D.
+      es | ee-e1 | some error message-E with value {0}. | null | algún mensaje de error-E con valor null.
+      es | ff_f1 | some error message-F with value {0}. | ''   | algún mensaje de error-F con valor .
+      es | gggg1 | some error message-G with value {0}. | '  ' | algún mensaje de error-G con valor   .
+      es | hhhh1 | some error message-H with value {0}. | JJKK | algún mensaje de error-H con valor JJKK.
+
+      de | aa    | some error message-A.                | null | einige Fehlermeldung-A.
+      de | bb    | some error message-B.                | ''   | einige Fehlermeldung-B.
+      de | cc.c  | some error message-C.                | '  ' | einige Fehlermeldung-C.
+      de | dc.d  | some error message-D.                | JJKK | einige Fehlermeldung-D.
+      de | ee-e1 | some error message-E with value {0}. | null | einige Fehlermeldung-E mit Wert null.
+      de | ff_f1 | some error message-F with value {0}. | ''   | einige Fehlermeldung-F mit Wert .
+      de | gggg1 | some error message-G with value {0}. | '  ' | einige Fehlermeldung-G mit Wert   .
+      de | hhhh1 | some error message-H with value {0}. | JJKK | einige Fehlermeldung-H mit Wert JJKK.
+      """, delimiter = '|', nullValues = "null")
+  void getLocalizedMessage_returnsAsExpected(
+      final String language,
+      final String messageCodeString, final String messageCodeMessage,
+      final String messageCodeArgs,
+      final String expectedMessage) {
+
+    final var locale = new Locale(language);
+    final var messageCode = MessageCode.of(messageCodeString, messageCodeMessage);
+
+    final var typeParserBuilderException = TypeParserBuilderException.builder()
+        .messageCode(messageCode)
+        .addMessageCodeArg("some-arg", messageCodeArgs)
+        .build();
+
+    final var actual = typeParserBuilderException.getLocalizedMessage(locale);
+
+    assertThat(actual)
+        .isNotNull()
+        .isNotEmpty()
+        .isEqualTo(expectedMessage);
+  }
+
+  @Test
+  void toString_createsExpectedString() {
+
+    when(cause.getMessage()).thenReturn("some exception message");
+
+    final var actual = TypeParserBuilderException.builder()
+        .cause(cause)
+        .messageCode(ERROR_MESSAGE_CODE_WITH_ARGS)
+        .addMessageCodeArg("invalidCodePoint", "A")
+        .build();
+
+    assertThat(actual).hasToString("""
+        TypeParserBuilderException{message='some default error message because of A', messageCode='some.error.code', defaultErrorMessage='some default error message because of {0}', invalidCodePoint='A', cause='Exception - some exception message'}""");
+  }
+}

--- a/type-factory-core/src/test/java/org/typefactory/TypeParserBuilderExceptionTest.java
+++ b/type-factory-core/src/test/java/org/typefactory/TypeParserBuilderExceptionTest.java
@@ -187,7 +187,19 @@ class TypeParserBuilderExceptionTest {
   }
 
   @Test
-  void toString_createsExpectedString() {
+  void toString_withoutCauseCreatesExpectedString() {
+
+    final var actual = TypeParserBuilderException.builder()
+        .messageCode(ERROR_MESSAGE_CODE_WITH_ARGS)
+        .addMessageCodeArg("invalidCodePoint", "A")
+        .build();
+
+    assertThat(actual).hasToString("""
+        TypeParserBuilderException{message='some default error message because of A', messageCode='some.error.code', defaultErrorMessage='some default error message because of {0}', invalidCodePoint='A'}""");
+  }
+
+  @Test
+  void toString_withCauseCreatesExpectedString() {
 
     when(cause.getMessage()).thenReturn("some exception message");
 

--- a/type-factory-core/src/test/java/org/typefactory/impl/TypeParser_ConvertDecimalDigitsTest.java
+++ b/type-factory-core/src/test/java/org/typefactory/impl/TypeParser_ConvertDecimalDigitsTest.java
@@ -30,7 +30,9 @@ public class TypeParser_ConvertDecimalDigitsTest {
       ZERO_DIGIT | VALUE      |  EXPECTED
       0          | 0123456789 |  0123456789
       0          | 9876543210 |  9876543210
+      0          | 01234ABCDE |  01234ABCDE
       0          | ０１２３４５６７８９ | 0123456789
+      0          | ０１２３４ＡＢＣＤＥ | 01234ＡＢＣＤＥ
       1          | 0123456789 | TypeParserBuilderException
       A          | 0123456789 | TypeParserBuilderException
       ०          | 0123456789 | ०१२३४५६७८९

--- a/type-factory-core/src/test/java/org/typefactory/impl/TypeParser_ConvertDecimalDigitsTest.java
+++ b/type-factory-core/src/test/java/org/typefactory/impl/TypeParser_ConvertDecimalDigitsTest.java
@@ -1,0 +1,76 @@
+/*
+   Copyright 2021-2022 Evan Toliopoulos (typefactory.org)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.typefactory.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.typefactory.TypeParser;
+import org.typefactory.TypeParserBuilderException;
+
+public class TypeParser_ConvertDecimalDigitsTest {
+
+  @ParameterizedTest(name = "[{index}] {arguments}")
+  @CsvSource(textBlock = """
+      ZERO_DIGIT | VALUE      |  EXPECTED
+      0          | 0123456789 |  0123456789
+      0          | 9876543210 |  9876543210
+      0          | ０１２３４５６７８９ | 0123456789
+      1          | 0123456789 | TypeParserBuilderException
+      A          | 0123456789 | TypeParserBuilderException
+      ०          | 0123456789 | ०१२३४५६७८९
+      ൦          | 0123456789 | ൦൧൨൩൪൫൬൭൮൯
+      ०          | ०१२३४५६७८९  | ०१२३४५६७८९
+      0          | ०१२३४५६७८९  | 0123456789
+      ०          | ०१२३४56789  | ०१२३४५६७८९
+      0          | ०१२३४56789  | 0123456789
+      १          | ०१२३४५६७८९  | TypeParserBuilderException
+      अ          | ०१२३४५६७८९  | TypeParserBuilderException
+      0          | ൦൧൨൩൪൫൬൭൮൯ | 0123456789
+      ൦          | ൦൧൨൩൪൫൬൭൮൯ | ൦൧൨൩൪൫൬൭൮൯
+      ൦          | ൦൧൨൩൪56789  | ൦൧൨൩൪൫൬൭൮൯
+      0          | ൦൧൨൩൪56789  | 0123456789
+      ൩         | ൦൧൨൩൪൫൬൭൮൯ | TypeParserBuilderException
+      ഖ         | ൦൧൨൩൪൫൬൭൮൯ | TypeParserBuilderException
+      """, delimiter = '|', useHeadersInDisplayName = true)
+  public void testConvertDecimalDigits(
+      final char zeroDigit,
+      final String value,
+      final String expected) {
+
+    final var parserBuilder = TypeParser.builder()
+        .acceptAllUnicodeLetters()
+        .acceptAllUnicodeDecimalDigits();
+
+    if ("TypeParserBuilderException".equalsIgnoreCase(expected)) {
+
+      assertThatExceptionOfType(TypeParserBuilderException.class)
+          .isThrownBy(() -> parserBuilder.convertAnyDecimalDigitsToDigitsStartingWithZeroDigit(zeroDigit))
+          .withMessageContaining("An invalid zero digit has been configured for the type parser – the zero digit character must represent zero and the subsequent nine characters must be valid unicode decimal digits.");
+
+    } else {
+
+      final var parser = parserBuilder
+          .convertAnyDecimalDigitsToDigitsStartingWithZeroDigit(zeroDigit)
+          .build();
+
+      final var actual = parser.parseToString(value);
+      assertThat(actual).isEqualTo(expected);
+    }
+  }
+}

--- a/type-factory-core/src/test/java/org/typefactory/impl/TypeParser_ConvertDecimalDigitsTest.java
+++ b/type-factory-core/src/test/java/org/typefactory/impl/TypeParser_ConvertDecimalDigitsTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.typefactory.TypeParser;
 import org.typefactory.TypeParserBuilderException;
 
-public class TypeParser_ConvertDecimalDigitsTest {
+class TypeParser_ConvertDecimalDigitsTest {
 
   @ParameterizedTest(name = "[{index}] {arguments}")
   @CsvSource(textBlock = """
@@ -50,7 +50,7 @@ public class TypeParser_ConvertDecimalDigitsTest {
       ൩         | ൦൧൨൩൪൫൬൭൮൯ | TypeParserBuilderException
       ഖ         | ൦൧൨൩൪൫൬൭൮൯ | TypeParserBuilderException
       """, delimiter = '|', useHeadersInDisplayName = true)
-  public void testConvertDecimalDigits(
+  void testConvertDecimalDigits(
       final char zeroDigit,
       final String value,
       final String expected) {

--- a/type-factory-core/src/test/resources/org/typefactory/Messages_es.properties
+++ b/type-factory-core/src/test/resources/org/typefactory/Messages_es.properties
@@ -23,6 +23,11 @@ ff_f = algún mensaje de error-F.
 gggg = algún mensaje de error-G.
 hhhh = algún mensaje de error-H.
 
+ee-e1 = algún mensaje de error-E con valor {0}.
+ff_f1 = algún mensaje de error-F con valor {0}.
+gggg1 = algún mensaje de error-G con valor {0}.
+hhhh1 = algún mensaje de error-H con valor {0}.
+
 ss   = algún mensaje de error del analizador-S.
 tt   = algún mensaje de error del analizador-T.
 uu.u = algún mensaje de error del analizador-U.


### PR DESCRIPTION
This means that for custom types that accept numeric values, the user or client could provide them using the decimal digits most familiar to them.

This also caters to users copying-and-pasting numeric values from one screen to another where the copy-from is presented in, say, Devanagari digits, and the target application being pasted-to is expecting Western Arabic digits.